### PR TITLE
server: ignore sv_cvar configstring from master server for tvgame

### DIFF
--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -546,8 +546,20 @@ void SV_CL_ConfigstringModified(void)
 	char        *dup;
 	gameState_t oldGs;
 	int         len;
+	char        fs_game[MAX_CVAR_VALUE_STRING];
 
 	index = Q_atoi(Cmd_Argv(1));
+
+	// don't force cvars from master to viewers
+	if (svcls.isTVGame && index == CS_SVCVAR)
+	{
+		Cvar_VariableStringBuffer("fs_game", fs_game, sizeof(fs_game));
+		if (Q_strncmp(fs_game, MODNAME, sizeof(MODNAME)) == 0)
+		{
+			return;
+		}
+	}
+
 	if (index < 0 || index >= MAX_CONFIGSTRINGS)
 	{
 		Com_Error(ERR_DROP, "configstring < 0 or configstring >= MAX_CONFIGSTRINGS");

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -742,7 +742,8 @@ void SV_ShutdownGameProgs(void)
  */
 static void SV_InitGameVM(qboolean restart)
 {
-	int i;
+	int  i;
+	char fs_game[MAX_CVAR_VALUE_STRING];
 
 	// start the entity parsing at the beginning
 	sv.entityParsePoint = CM_EntityString();
@@ -756,9 +757,16 @@ static void SV_InitGameVM(qboolean restart)
 
 	if (svcls.isTVGame && !restart)
 	{
+		Cvar_VariableStringBuffer("fs_game", fs_game, sizeof(fs_game));
 		for (i = 0; i < MAX_CONFIGSTRINGS; i++)
 		{
 			if (!svcl.gameState.stringOffsets[i] || i == CS_SYSTEMINFO)
+			{
+				continue;
+			}
+
+			// don't force cvars from master to viewers
+			if (i == CS_SVCVAR && Q_strncmp(fs_game, MODNAME, sizeof(MODNAME)) == 0)
 			{
 				continue;
 			}


### PR DESCRIPTION
To not force cvars from master to tv viewers.